### PR TITLE
Improve deposit validation for Aurora bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,9 +10,12 @@ import os
 import requests
 import json
 from collections import defaultdict
+from typing import Final
 
 # --- Хранилище балансов пользователей: chat_id → данные ---
-user_balances: dict[int, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+user_balances: dict[int, dict[str, float]] = defaultdict(
+    lambda: defaultdict(float)
+)
 
 # --- Конфигурация ---
 # Читаем чувствительные данные из переменных окружения
@@ -22,18 +25,27 @@ WEBAPP_URL = os.environ.get(
     "WEBAPP_URL",
     "https://jumeaux34.github.io/aurora-webapp/index.html",
 )  # адрес WebApp
+ALLOWED_OFFICES: Final[set[str]] = {"moscow", "spb"}
+MAX_DEPOSIT_AMOUNT: Final[float] = 10000.0
+
+if not BOT_TOKEN:
+    raise ValueError("BOT_TOKEN environment variable is not set")
+
 
 # --- Вспомогательная функция для получения курса ---
 def get_price(symbol: str) -> float | None:
     try:
         r = requests.get(
             "https://api.coingecko.com/api/v3/simple/price",
-            params={"ids": symbol.lower(), "vs_currencies": "usd"}, timeout=5
+            params={"ids": symbol.lower(), "vs_currencies": "usd"},
+            timeout=5,
         )
+        r.raise_for_status()
         data = r.json()
         return data.get(symbol.lower(), {}).get("usd")
-    except:
+    except requests.RequestException:
         return None
+
 
 # --- /start: открывает весь интерфейс через WebApp ---
 async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -42,9 +54,13 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         web_app=WebAppInfo(url=WEBAPP_URL)
     )]]
     await update.message.reply_text(
-        "Добро пожаловать в AuroraCryptoBot!\nИспользуйте кнопку ниже, чтобы загрузить полностью веб-интерфейс:",
-        reply_markup=InlineKeyboardMarkup(kb)
+        (
+            "Добро пожаловать в AuroraCryptoBot!\n"
+            "Используйте кнопку ниже, чтобы загрузить полностью веб-интерфейс:"
+        ),
+        reply_markup=InlineKeyboardMarkup(kb),
     )
+
 
 # --- Приём данных из WebApp (JSON) ---
 async def webapp_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -56,22 +72,44 @@ async def webapp_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if action == "deposit":
         office = payload.get("office")
         amount = payload.get("amount")
+        try:
+            amount_value = float(amount)
+        except (TypeError, ValueError):
+            await update.message.reply_text("Некорректная сумма.")
+            return
+        if amount_value <= 0 or amount_value > MAX_DEPOSIT_AMOUNT:
+            await update.message.reply_text("Некорректная сумма.")
+            return
+        if office not in ALLOWED_OFFICES:
+            await update.message.reply_text("Неизвестный офис.")
+            return
+
         # Уведомляем администратора
         await context.bot.send_message(
             chat_id=ADMIN_CHAT_ID,
-            text=(f"🔔 Новая заявка на пополнение WebApp:\n"
-                  f"Пользователь: {user_id}\n"
-                  f"Офис: {office}\n"
-                  f"Сумма: {amount}"),
+            text=(
+                f"🔔 Новая заявка на пополнение WebApp:\n"
+                f"Пользователь: {user_id}\n"
+                f"Офис: {office}\n"
+                f"Сумма: {amount_value}"
+            ),
             reply_markup=InlineKeyboardMarkup([
-                [InlineKeyboardButton("✉️ Связаться", url=f"tg://user?id={user_id}")]
+                [
+                    InlineKeyboardButton(
+                        "✉️ Связаться",
+                        url=f"tg://user?id={user_id}",
+                    )
+                ]
             ])
         )
         # Ответ пользователю
-        await update.message.reply_text("✅ Ваша заявка на пополнение отправлена через WebApp.")
+        await update.message.reply_text(
+            "✅ Ваша заявка на пополнение отправлена через WebApp."
+        )
     # Здесь можно добавить другие action: exchange, withdraw и т.д.
     else:
         await update.message.reply_text("⚠️ Неизвестное действие из WebApp.")
+
 
 # --- Обработчики команд (резервно) ---
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -79,6 +117,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "/start — загрузить веб-интерфейс\n"
         "/help — помощь"
     )
+
 
 # --- Точка входа ---
 def main():
@@ -88,10 +127,16 @@ def main():
     app.add_handler(CommandHandler("start", start_handler))
     app.add_handler(CommandHandler("help", help_command))
     # WebApp-data
-    app.add_handler(MessageHandler(filters.StatusUpdate.WEB_APP_DATA, webapp_handler))
+    app.add_handler(
+        MessageHandler(
+            filters.StatusUpdate.WEB_APP_DATA,
+            webapp_handler,
+        )
+    )
 
     print("AuroraCryptoBot запущен…")
     app.run_polling()
+
 
 if __name__ == "__main__":
     main()

--- a/deposit.html
+++ b/deposit.html
@@ -19,7 +19,7 @@
       </div>
       <div>
         <label class="block mb-1">Сумма</label>
-        <input type="number" id="amount" placeholder="1000" class="w-full p-2 rounded-lg bg-transparent border border-white/50">
+        <input type="number" id="amount" placeholder="1000" min="0.01" step="0.01" max="10000" class="w-full p-2 rounded-lg bg-transparent border border-white/50">
       </div>
       <button id="send" class="w-full py-3 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 rounded-full text-xl font-bold hover:opacity-90 transition">Отправить заявку</button>
     </div>
@@ -29,10 +29,15 @@
     const tg = window.Telegram.WebApp;
     tg.expand();
     document.getElementById('send').onclick = () => {
+      const amount = parseFloat(document.getElementById('amount').value);
+      if (!amount || amount <= 0 || amount > 10000) {
+        alert('Некорректная сумма');
+        return;
+      }
       const data = {
         action: 'deposit',
         office: document.getElementById('office').value,
-        amount: document.getElementById('amount').value
+        amount
       };
       tg.sendData(JSON.stringify(data));
     };

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
             </div>
             <div>
               <label class="block mb-1">Сумма</label>
-              <input type="number" id="deposit-amount" placeholder="1000" class="w-full p-2 rounded-lg bg-transparent border border-white/50">
+              <input type="number" id="deposit-amount" placeholder="1000" min="0.01" step="0.01" max="10000" class="w-full p-2 rounded-lg bg-transparent border border-white/50">
             </div>
             <button id="deposit-send" class="w-full py-3 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 rounded-full text-xl font-bold hover:opacity-90 transition">Отправить заявку</button>
           </div>
@@ -111,7 +111,11 @@
     // Заказ пополнения
     document.getElementById('deposit-send').onclick = () => {
       const office = document.getElementById('deposit-office').value;
-      const amount = document.getElementById('deposit-amount').value;
+      const amount = parseFloat(document.getElementById('deposit-amount').value);
+      if (!amount || amount <= 0 || amount > 10000) {
+        alert('Некорректная сумма');
+        return;
+      }
       tg.sendData(JSON.stringify({ action: 'deposit', office, amount }));
     };
 


### PR DESCRIPTION
## Summary
- enforce token presence
- validate deposit amount and office on server side
- add client-side checks for deposit forms
- use shorter lines and add Flake8 compliance improvements

## Testing
- `flake8 bot.py`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68589a046c1c8323af9b22f4f04eaef0